### PR TITLE
Fix grammar

### DIFF
--- a/2-Basic-neural-networks/Regression-model-wine-quality.ipynb
+++ b/2-Basic-neural-networks/Regression-model-wine-quality.ipynb
@@ -202,7 +202,7 @@
     "\n",
     "The first column of our dataset is \"type\". It can be either \"white\" or \"red\". The network doesn't understand that. It only understands numbers.\n",
     "\n",
-    "We could attribute each type with a number. Let's red is 0, and white is 1. But that would not work! The network needs a clearer distinction of what is what.\n",
+    "We could attribute each type with a number. Let red be 0, and white be 1. But that would not work! The network needs a clearer distinction of what is what.\n",
     "\n",
     "Instead, we are going to give each wine time its own neuron. If it is \"red\", only the first input neuron will be 1. If it \"white\", only the second neuron will be 1.\n",
     "\n",


### PR DESCRIPTION
The following sentence does not make sense: `Let's red is [...]`. If we change it to either `Let's say` or `Let red be 0 and white be 1`.